### PR TITLE
[FIX] fixed bug of getting provider name when sdk minimized

### DIFF
--- a/lib/provider-util.js
+++ b/lib/provider-util.js
@@ -13,7 +13,7 @@ var Provider = (function(){
     this._data = authData;
   }
   Provider.prototype.getName = function(){
-    return this.constructor.name.toLowerCase();
+    return this.providerName;
   };
   Provider.prototype.getAuthData = function(){
     return this._data;
@@ -27,6 +27,7 @@ var Provider = (function(){
 var Facebook = (function(superClass){
   extend(Facebook, superClass);
   function Facebook (){
+    this.providerName = "facebook";
     return Facebook.__super__.constructor.apply(this, arguments);
   }
   Facebook.prototype.validate = function(authData){
@@ -40,6 +41,7 @@ var Facebook = (function(superClass){
 var Twitter = (function(superClass){
   extend(Twitter, superClass);
   function Twitter (){
+    this.providerName = "twitter";
     return Twitter.__super__.constructor.apply(this, arguments);
   }
   Twitter.prototype.validate = function(authData){
@@ -53,6 +55,7 @@ var Twitter = (function(superClass){
 var Google = (function(superClass){
   extend(Google, superClass);
   function Google (){
+    this.providerName = "google";
     return Google.__super__.constructor.apply(this, arguments);
   }
   Google.prototype.validate = function(authData){


### PR DESCRIPTION
* ncmb.min.jsでprovide名が正しく取得できないバグを修正しました。
  * getNameで引き継いだ変数ではなくコンストラクタ名を返しており、sdk最小化時にはローカル関数の名前が変換されているため、おかしな値が返っていました。