### PR TITLE
Fix_query_count

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -573,8 +573,9 @@ var Query = module.exports = (function(){
           if(object.acl) object.acl = new this.ncmb.Acl(object.acl);
           return object;
         }.bind(this));
-        if("count" in JSON.parse(data)){
-          objects.count = JSON.parse(data).count;
+        var parsedData = JSON.parse(data)
+        if("count" in parsedData){
+          objects.count = parsedData.count;
         }
       }catch(err){
         if(callback) return callback(err, null);

--- a/lib/query.js
+++ b/lib/query.js
@@ -573,7 +573,7 @@ var Query = module.exports = (function(){
           if(object.acl) object.acl = new this.ncmb.Acl(object.acl);
           return object;
         }.bind(this));
-        if(JSON.parse(data).count){
+        if("count" in JSON.parse(data)){
           objects.count = JSON.parse(data).count;
         }
       }catch(err){

--- a/test/mbaas.yml
+++ b/test/mbaas.yml
@@ -1010,6 +1010,16 @@
     file: 2013-09-01_classes_querytest_get_count_success.json
 -
   request:
+    url: /2013-09-01/classes/QueryTestCount
+    method: GET
+    query:
+      count: 1
+      where: '{"nullField":"exist"}'
+  response:
+    status: 200
+    file: 2013-09-01_classes_querytest_get_count_zero_success.json
+-
+  request:
     url: /2013-09-01/classes/QueryTestOrder
     method: GET
     query:

--- a/test/query_test.js
+++ b/test/query_test.js
@@ -1579,6 +1579,39 @@ describe("NCMB Query", function(){
           });
         });
       });
+      context("検索結果が0件のとき件数が正しく返り", function(){
+        beforeEach(function(){
+          QueryTest = ncmb.DataStore("QueryTestCount");
+        });
+        it("callback で取得できる", function(done){
+          QueryTest
+          .count()
+          .equalTo("nullField", "exist")
+          .fetchAll(function(err, objs){
+            if(err){
+              done(err);
+            }else{
+              expect(objs.length).to.be.equal(0);
+              expect(objs.count).to.be.equal(0);
+              done();
+            }
+          });
+        });
+        it("promise で取得できる", function(done){
+          QueryTest
+          .count()
+          .equalTo("nullField", "exist")
+          .fetchAll()
+          .then(function(objs){
+            expect(objs.length).to.be.equal(0);
+            expect(objs.count).to.be.equal(0);
+            done();
+          })
+          .catch(function(err){
+            done(err);
+          });
+        });
+      });
     });
     describe("order", function(){
       context("指定したkeyの昇順でリストが返り", function(){

--- a/test/stub/2013-09-01_classes_querytest_get_count_zero_success.json
+++ b/test/stub/2013-09-01_classes_querytest_get_count_zero_success.json
@@ -1,0 +1,1 @@
+{"results":[],"count":0}


### PR DESCRIPTION
### 概要

検索でcountオプション利用時に、検索結果が0件だとpropertyの存在判定でfalse扱いになり、値が返ってこなかった不具合を修正しました。

### 確認方法

- [ ] テストが通ること