### PR TITLE
[FIX] fixed file upload to set mime-type correctly

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var fs     = require("fs");
 var Errors = require("./errors");
 var Query  = require("./query");
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -122,7 +122,7 @@ module.exports = function(opts, callback){
       if(file.acl !== undefined){
         r.field("acl", JSON.stringify(file.acl));
       }
-      r.attach("file", file.fileData, file.fileName);
+      r.attach("file", file.fileData, {filename: file.fileName});
       r.end(_callback);
     }else{
       if(typeof data == "object"){


### PR DESCRIPTION
### 概要

* ファイルアップロード時にmimetypeがすべてtext/plainになってしまう不具合を修正しました。
  * ファイルそのものの形式や、DL時の復元は正常に行われていました。

### 確認方法

- [ ] 実環境でncmb.File.uploadを実行し、mimetypeが正しいことが確認できること( jpg, png, zip. text 等)