### PR TITLE
ブラウザからのファイルアップロード対応修正

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -51,7 +51,7 @@ var File = module.exports = function(ncmb){
       path: "/" + ncmb.version + this.className + "/" + fileName,
       method: "POST",
       file: { fileName: fileName, fileData: fileData, acl: acl },
-      contentType: "multipart/form-data"
+      contentType: null
     })
     .then(function(data){
       var obj = null;

--- a/lib/request.js
+++ b/lib/request.js
@@ -96,10 +96,14 @@ module.exports = function(opts, callback){
     "X-NCMB-Application-Key":    opts.apikey || this.apikey,
     "X-NCMB-Signature":          sig,
     "X-NCMB-Timestamp":          timestamp,
-    "Content-Type":              typeof opts.contentType == 'undefined' ? "application/json" : opts.contentType,
+    "Content-Type":              opts.contentType || "application/json",
     "X-NCMB-SDK-Version":        "javascript-2.0.2"
   };
-
+  
+  if (opts.contentType == null) {
+    delete headers["Content-Type"];
+  }
+  
   if(this.sessionToken) headers["X-NCMB-Apps-Session-Token"] = this.sessionToken;
 
   if(parsedUrl.protocol === "https:") var secureProtocol = "TLSv1_method";
@@ -115,8 +119,6 @@ module.exports = function(opts, callback){
     };
     var r = request[method.toLowerCase()](url);
     Object.keys(headers).forEach(function(key){
-      if (headers[key] == null)
-        return true;
       r.set(key, headers[key]);
     });
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -96,7 +96,7 @@ module.exports = function(opts, callback){
     "X-NCMB-Application-Key":    opts.apikey || this.apikey,
     "X-NCMB-Signature":          sig,
     "X-NCMB-Timestamp":          timestamp,
-    "Content-Type":              opts.contentType || "application/json",
+    "Content-Type":              typeof opts.contentType == 'undefined' ? "application/json" : opts.contentType,
     "X-NCMB-SDK-Version":        "javascript-2.0.2"
   };
 
@@ -115,6 +115,8 @@ module.exports = function(opts, callback){
     };
     var r = request[method.toLowerCase()](url);
     Object.keys(headers).forEach(function(key){
+      if (headers[key] == null)
+        return true;
       r.set(key, headers[key]);
     });
 


### PR DESCRIPTION
ファイルアップロードを行う際に、ヘッダーが"multipart/form-data"固定となっていましたので外しました。これにより自動で `multipart/form-data; boundary=----WebKitFormBoundaryRH4oXOXCEELYUy7y` といったヘッダーが追加されるようになります。

requestの方はnullで渡しても"application/json"を適用してしまうので、その後でヘッダーのキー自体を消すようにしています。