### PR TITLE
Fix/file upload on browser

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -96,10 +96,10 @@ module.exports = function(opts, callback){
     "X-NCMB-Application-Key":    opts.apikey || this.apikey,
     "X-NCMB-Signature":          sig,
     "X-NCMB-Timestamp":          timestamp,
-    "Content-Type":              opts.contentType || "application/json",
     "X-NCMB-SDK-Version":        "javascript-2.1.0"
   };
 
+  if(!file)             headers["Content-Type"] = "application/json";
   if(this.sessionToken) headers["X-NCMB-Apps-Session-Token"] = this.sessionToken;
 
   if(parsedUrl.protocol === "https:") var secureProtocol = "TLSv1_method";

--- a/lib/request.js
+++ b/lib/request.js
@@ -109,6 +109,8 @@ module.exports = function(opts, callback){
 
   return new Promise(function(resolve, reject){
     var _callback = function(err, res){
+      if(err && err.response && err.response.error) return _callback(err.response.error, res);
+
       if(err) return (callback && callback(err, null)) || reject(err);
       if(res.statusCode >= 400 || res.status >= 400) return reject(res.error || new Error(res.text));
       return (callback && callback(null, res.text)) || resolve(res.text, res);

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "object-assign": "^3.0.0",
     "qs": "^2.4.1",
     "request": "^2.53.0",
-    "superagent": "^0.21.0",
+    "superagent": "^1.8.2",
     "superagent-proxy": "^0.3.1",
     "uglifyify": "^3.0.1",
     "url": "^0.10.3"


### PR DESCRIPTION
# 概要
- ブラウザでのfileupload対応のため、superagentのバージョンを0.x系から1.x系に更新しました。
- superagentの更新に合わせ、返却されるエラーが従来と同様になるよう変更しました。

# 確認方法
- [x] テストが正常に完了する。
- [x] ブラウザからのファイルのアップロードが成功する。
- [x] monaca環境からのファイルのアップロードが成功する。