### PR TITLE
Fix/enabled proxy on node.js

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -82,7 +82,6 @@ module.exports = function(opts, callback){
   var url = parsedUrl.format();
   var query = opts.query;
   var data  = opts.data;
-  var proxy = null;
   var file  = opts.file;
 
   var sig = (this.createSignature || require("./signature").create)(
@@ -104,9 +103,6 @@ module.exports = function(opts, callback){
   if(this.sessionToken) headers["X-NCMB-Apps-Session-Token"] = this.sessionToken;
 
   if(parsedUrl.protocol === "https:") var secureProtocol = "TLSv1_method";
-  if(typeof (opts.proxy || this.proxy) === "undefined"){
-    proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || "";
-  }
 
   return new Promise(function(resolve, reject){
     var _callback = function(err, res){
@@ -121,6 +117,7 @@ module.exports = function(opts, callback){
       r.set(key, headers[key]);
     });
 
+    var proxy = this.proxy || process.env.HTTPS_PROXY || process.env.HTTP_PROXY || "";
     if(requestProxy && proxy){
       requestProxy(request);
       r.proxy(proxy);

--- a/lib/request.js
+++ b/lib/request.js
@@ -4,6 +4,7 @@ require("babel/polyfill");
 var Url     = require("url");
 var qs      = require("qs");
 var request = require("superagent");
+var requestProxy = require('superagent-proxy');
 
 var toPointer = function(obj, ncmb){
   var className = null;
@@ -119,6 +120,12 @@ module.exports = function(opts, callback){
     Object.keys(headers).forEach(function(key){
       r.set(key, headers[key]);
     });
+
+    if(requestProxy && proxy){
+      requestProxy(request);
+      r.proxy(proxy);
+      r.set({host: this.fqdn});
+    }
 
     if(typeof file == "object"){
       if(file.acl !== undefined){

--- a/lib/request_script.js
+++ b/lib/request_script.js
@@ -4,6 +4,7 @@ require("babel/polyfill");
 var Url     = require("url");
 var qs      = require("qs");
 var request = require("superagent");
+var requestProxy = require('superagent-proxy');
 
 module.exports = function(opts, callback){
   if(typeof opts.path != "string"){
@@ -51,6 +52,7 @@ module.exports = function(opts, callback){
     proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || "";
   }
 
+
   return new Promise(function(resolve, reject){
     var _callback = function(err, res){
       if(err) return (callback && callback(err, null)) || reject(err);
@@ -64,6 +66,13 @@ module.exports = function(opts, callback){
     if(optionalHeader) r.set(optionalHeader);
 
     r.set(baseHeaders);
+
+    if(requestProxy && proxy){
+      requestProxy(request);
+      r.proxy(proxy);
+      r.set({host: this.fqdn});
+    }
+
     r.end(_callback);
   }.bind(this));
 };

--- a/lib/request_script.js
+++ b/lib/request_script.js
@@ -24,7 +24,6 @@ module.exports = function(opts, callback){
   var data           = opts.data;
   var query          = opts.query;
   var optionalHeader = opts.header;
-  var proxy          = null;
 
   var queryString = method === "GET" ? query : {};
   var sig = (this.createSignature || require("./signature").create)(
@@ -48,10 +47,6 @@ module.exports = function(opts, callback){
   if(this.sessionToken) baseHeaders["X-NCMB-Apps-Session-Token"] = this.sessionToken;
 
   if(parsedUrl.protocol === "https:") var secureProtocol = "TLSv1_method";
-  if(typeof (opts.proxy || this.proxy) === "undefined"){
-    proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || "";
-  }
-
 
   return new Promise(function(resolve, reject){
     var _callback = function(err, res){
@@ -67,6 +62,7 @@ module.exports = function(opts, callback){
 
     r.set(baseHeaders);
 
+    var proxy = this.proxy || process.env.HTTPS_PROXY || process.env.HTTP_PROXY || "";
     if(requestProxy && proxy){
       requestProxy(request);
       r.proxy(proxy);

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "mocha": "^2.1.0",
     "stubcell": "^0.8.0"
   },
+  "browser": {
+    "superagent-proxy": false
+  },
   "scripts": {
     "test": "nohup npm run stub:start & sleep 5 && NODE_ENV=test mocha -R list test/**_test.js && npm run cov:80 && npm run stub:stop",
     "coverage": "NODE_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec test/**_test.js && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",

--- a/test/acl_test.js
+++ b/test/acl_test.js
@@ -13,7 +13,7 @@ describe("NCMB ACL", function(){
       .set("protocol", config.apiserver.protocol || "http:")
       .set("fqdn", config.apiserver.fqdn)
       .set("port", config.apiserver.port)
-      .set("proxy", config.apiserver.port || "");
+      .set("proxy", config.apiserver.proxy || "");
   }
 
   var aclObj = null;

--- a/test/geopoint_test.js
+++ b/test/geopoint_test.js
@@ -17,7 +17,7 @@ describe("NCMB GeoPoint", function(){
       .set("protocol", config.apiserver.protocol || "http:")
       .set("fqdn",     config.apiserver.fqdn)
       .set("port",     config.apiserver.port)
-      .set("proxy",    config.apiserver.port || "");
+      .set("proxy",    config.apiserver.proxy || "");
     }
   });
 

--- a/test/installations_test.js
+++ b/test/installations_test.js
@@ -13,7 +13,7 @@ describe("NCMB Installation", function(){
       ncmb.set("protocol", config.apiserver.protocol || "http:")
           .set("fqdn", config.apiserver.fqdn)
           .set("port", config.apiserver.port)
-          .set("proxy", config.apiserver.port || "");
+          .set("proxy", config.apiserver.proxy || "");
     }
   });
   var installation = null;

--- a/test/monaca/js/acl_test.js
+++ b/test/monaca/js/acl_test.js
@@ -7,7 +7,7 @@ describe("NCMB ACL", function(){
       .set("protocol", config.apiserver.protocol || "http:")
       .set("fqdn", config.apiserver.fqdn)
       .set("port", config.apiserver.port)
-      .set("proxy", config.apiserver.port || "");
+      .set("proxy", config.apiserver.proxy || "");
   }
 
   var aclObj = null;

--- a/test/monaca/js/geopoint_test.js
+++ b/test/monaca/js/geopoint_test.js
@@ -10,7 +10,7 @@ describe("NCMB GeoPoint", function(){
       .set("protocol", config.apiserver.protocol || "http:")
       .set("fqdn",     config.apiserver.fqdn)
       .set("port",     config.apiserver.port)
-      .set("proxy",    config.apiserver.port || "");
+      .set("proxy",    config.apiserver.proxy || "");
     }
   });
 

--- a/test/monaca/js/operation_test.js
+++ b/test/monaca/js/operation_test.js
@@ -8,7 +8,7 @@ describe("NCMB Operation", function(){
       ncmb.set("protocol", config.apiserver.protocol || "http:")
           .set("fqdn", config.apiserver.fqdn)
           .set("port", config.apiserver.port)
-          .set("proxy", config.apiserver.port || "");
+          .set("proxy", config.apiserver.proxy || "");
     }
   });
   describe("プロパティ設定", function(){

--- a/test/monaca/js/push_test.js
+++ b/test/monaca/js/push_test.js
@@ -9,7 +9,7 @@ describe("NCMB Push", function(){
       ncmb.set("protocol", config.apiserver.protocol || "http:")
           .set("fqdn", config.apiserver.fqdn)
           .set("port", config.apiserver.port)
-          .set("proxy", config.apiserver.port || "");
+          .set("proxy", config.apiserver.proxy || "");
     }
   });
   var push = null;

--- a/test/monaca/js/users_test.js
+++ b/test/monaca/js/users_test.js
@@ -14,7 +14,7 @@ describe("NCMB Users", function(){
       .set("protocol", config.apiserver.protocol || "http:")
       .set("fqdn", config.apiserver.fqdn)
       .set("port", config.apiserver.port)
-      .set("proxy", config.apiserver.port || "");
+      .set("proxy", config.apiserver.proxy || "");
     }
   });
   

--- a/test/operation_test.js
+++ b/test/operation_test.js
@@ -13,7 +13,7 @@ describe("NCMB Operation", function(){
       ncmb.set("protocol", config.apiserver.protocol || "http:")
           .set("fqdn", config.apiserver.fqdn)
           .set("port", config.apiserver.port)
-          .set("proxy", config.apiserver.port || "");
+          .set("proxy", config.apiserver.proxy || "");
     }
   });
   describe("プロパティ設定", function(){

--- a/test/push_test.js
+++ b/test/push_test.js
@@ -13,7 +13,7 @@ describe("NCMB Push", function(){
       ncmb.set("protocol", config.apiserver.protocol || "http:")
           .set("fqdn", config.apiserver.fqdn)
           .set("port", config.apiserver.port)
-          .set("proxy", config.apiserver.port || "");
+          .set("proxy", config.apiserver.proxy || "");
     }
   });
   var push = null;

--- a/test/script_test.js
+++ b/test/script_test.js
@@ -13,7 +13,7 @@ describe("NCMB Script", function(){
       ncmb.set("protocol", config.apiserver.protocol || "http:")
           .set("scriptFqdn", config.apiserver.scriptFqdn)
           .set("port", config.apiserver.port)
-          .set("proxy", config.apiserver.port || "");
+          .set("proxy", config.apiserver.proxy || "");
      }
   });
 

--- a/test/users_test.js
+++ b/test/users_test.js
@@ -14,7 +14,7 @@ describe("NCMB Users", function(){
       .set("protocol", config.apiserver.protocol || "http:")
       .set("fqdn", config.apiserver.fqdn)
       .set("port", config.apiserver.port)
-      .set("proxy", config.apiserver.port || "");
+      .set("proxy", config.apiserver.proxy || "");
     }
   });
 


### PR DESCRIPTION
# 概要
- node.jsでのproxy設定が反映されていなかった挙動を修正しました。
- node.jsでのncmb.setメソッドでのproxy設定が握りつぶされる不具合を修正しました。

# 確認方法
- [x] proxy環境下で環境変数HTTPS_PROXYもしくはHTTPS_PROXYにproxy情報を指定し、node.jsでリクエストが成功する。
- [x] proxy環境下でncmb.setメソッドでproxyを指定し、node.jsでリクエストが成功する。