### PR TITLE
fix/ncmb_setter

### DIFF
--- a/lib/ncmb.js
+++ b/lib/ncmb.js
@@ -60,7 +60,7 @@ var NCMB = module.exports = (function(){
   NCMB.prototype.set = function(key, val){
     if(!isModifiable(key))
       throw new this.Errors.UnmodifiableVariableError(key + " cannot be set, it is reserved.");
-    this[key] = val;
+    if(typeof val !== "undefined") this[key] = val;
     return this;
   };
 


### PR DESCRIPTION
### 概要
* NCMBクラスのsetterで、valueがundefinedの場合にはプロパティを作成しないようにしました
  * keyの有無で判別する処理があるため

### 確認事項
- [x] `npm test`が通ること