### PR TITLE
Fix/put mailaddress only if changed

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -36,7 +36,7 @@ var User = module.exports = function(ncmb){
     "update", "delete", "logout", "requestPasswordReset",
     "signUpByAccount", "signUpWith", "requestSignUpEmail",
     "login", "loginAsAnonymous", "loginWithMailAddress", "loginWith",
-    "getCurrentUser", "isCurrentUser",
+    "getCurrentUser", "isCurrentUser", "_mailAddressChanged",
     "setIncrement", "add", "addUnique", "remove"];
 
   var isReserved = function(key){
@@ -44,7 +44,7 @@ var User = module.exports = function(ncmb){
   };
 
   var unreplaceable =[
-    "objectId", "password", "createDate", "updateDate", "mailAddressConfirm", "_id", "sessionToken"
+    "objectId", "password", "createDate", "updateDate", "mailAddressConfirm", "_id", "sessionToken", "_mailAddressChanged"
   ];
 
   var isReplaceable = function(key){
@@ -74,13 +74,21 @@ var User = module.exports = function(ncmb){
     }
   });
   Object.keys(Operation.prototype).forEach(function(attr){
-    if(attr !== "batch" && typeof Operation.prototype[attr] === "function"){
+    if(attr !== "batch" && attr !== "set" && typeof Operation.prototype[attr] === "function"){
       User.prototype[attr] = function(){
         var operation = new Operation(reserved);
         return operation[attr].apply(this, [].slice.apply(arguments));
       };
     }
   });
+
+  User.prototype.set = function(key, value){
+    if(typeof key !== "string") throw new Errors.InvalidArgumentError("Key must be string.");
+    if(isReserved(key))         throw new Errors.UnReplaceableKeyError(key + " cannot be set, it is reserved.");
+    if(key == "mailAddress") this._mailAddressChanged = true;
+    this[key] = value;
+    return this;
+  };
 
   /**
   * 現在セッションに使用しているユーザの情報を取得します。
@@ -149,6 +157,7 @@ var User = module.exports = function(ncmb){
       Object.keys(this).forEach(function (key) {
         if(this[key] && this[key].__op) delete this[key];
       }.bind(this));
+      if(this._mailAddressChanged) delete this._mailAddressChanged;
 
       if(callback) return callback(null, this);
       return this;
@@ -288,6 +297,7 @@ var User = module.exports = function(ncmb){
     var replaceProperties = {};
     Object.keys(this).forEach(function(key){
       if(!isReplaceable(key)) return;
+      if(key == "mailAddress" && !this._mailAddressChanged) return;
       replaceProperties[key] = this[key];
     }.bind(this));
 

--- a/test/mbaas.yml
+++ b/test/mbaas.yml
@@ -409,6 +409,15 @@
 
 -
   request:
+    url: /2013-09-01/users/objectid
+    method: PUT
+    body: {"mailAddress": "test@example.com"}
+  response:
+    status: 201
+    file: 2013-09-01_users_update_success.json
+
+-
+  request:
     url: /2013-09-01/users
     method: POST
     body:

--- a/test/users_test.js
+++ b/test/users_test.js
@@ -3380,6 +3380,75 @@ describe("NCMB Users", function(){
         });
       });
     });
+    context("mailAddressを保持したインスタンスを更新した場合", function(){
+      beforeEach(function(done){
+        if(!ncmb.stub){
+          user = new ncmb.User({userName:callback_name,password:callback_password,mailAddress:"test@example.com"});
+          ncmb.User
+              .login(user)
+              .then(function(){
+                done();
+              })
+              .catch(function(){
+                done(new Error("前処理に失敗しました。"));
+              });
+        }else{
+          user = new ncmb.User({ objectId:"objectid", mailAddress: "test@example.com"});
+          done();
+        }
+      });
+      context("mailAddressをsetし直さなければbodyに含めずにリクエストして", function(){
+        it("callback でレスポンスを取得できる", function(done){
+          user.set("updatefield", "updated")
+              .update(function(err, data){
+                if(err){
+                  done(err);
+                }else{
+                  expect(data.updateDate).to.exist;
+                  done();
+                }
+              });
+        });
+
+        it("promise でレスポンスを取得できる", function(done){
+          user.set("updatefield", "updated")
+              .update()
+              .then(function(data){
+                expect(data.updateDate).to.exist;
+                done();
+              })
+              .catch(function(err){
+                done(err);
+              });
+        });
+      });
+
+      context("mailAddressをsetし直したらbodyに含めてリクエストして", function(){
+        it("callback でレスポンスを取得できる", function(done){
+          user.set("mailAddress", "test@example.com")
+              .update(function(err, data){
+                if(err){
+                  done(err);
+                }else{
+                  expect(data.updateDate).to.exist;
+                  done();
+                }
+              });
+        });
+
+        it("promise でレスポンスを取得できる", function(done){
+          user.set("mailAddress", "test@example.com")
+              .update()
+              .then(function(data){
+                expect(data.updateDate).to.exist;
+                done();
+              })
+              .catch(function(err){
+                done(err);
+              });
+        });
+      });
+    });
 
     context("失敗した理由が", function(){
       context("objectId がないときに", function(){


### PR DESCRIPTION
### 概要
- Userインスタンスの更新時に意図しないmailAddressの更新が発生しないように修正しました
    -  Userクラスの更新時に、mailAddressがsetで追加・更新されていない場合はリクエストに含めないように変更

### 確認事項
- [x] `npm test`が成功すること